### PR TITLE
메뉴 아이템마다 바닥 보더에 애니매이션 추가하기

### DIFF
--- a/_sass/commons.scss
+++ b/_sass/commons.scss
@@ -1,3 +1,6 @@
+$white: #fff;
+$text-color-primary: #2c3144;
+
 * {
     box-sizing: border-box;
     -webkit-font-smoothing: antialiased;
@@ -5,7 +8,7 @@
 }
 
 ::selection {
-    color: #fff;
+    color: $white;
     background: rgba(34, 34, 34, 0.5);
 }
 
@@ -227,11 +230,11 @@ h2 {
     margin-top: 4em;
     margin-bottom: 1.2em;
     font-size: 1em;
-    color: #2c3144;
+    color: $text-color-primary;
 }
 
 h1, h3, h4, h5, h6 {
-    color: #2c3144;
+    color: $text-color-primary;
 }
 
 h2::before {
@@ -289,7 +292,7 @@ h2::before {
     top: -160px;
     width: 100%;
     height: 320px;
-    background-color: #2c3144;
+    background-color: $text-color-primary;
     transform: skew(0, 12deg);
 }
 
@@ -373,7 +376,7 @@ p.main_description span sup {
     display: none;
     padding: 8px;
     background-color: #ff9900;
-    color: #2c3144;
+    color: $text-color-primary;
     font-weight: bold;
 }
 
@@ -395,7 +398,7 @@ p.main_description span sup {
     border-top: 1px solid #d8d8d8;
     margin-top: 16px;
     padding: 16px;
-    color: #2c3144;
+    color: $text-color-primary;
 }
 
 /*
@@ -439,8 +442,7 @@ html, body {
 .trigger {
     display: block;
     background: none;
-    color: white;
+    color: $white;
     font-size: 18px;
 }
-
 }

--- a/_sass/commons.scss
+++ b/_sass/commons.scss
@@ -383,6 +383,19 @@ p.main_description span sup {
 .trigger a.page-link {
     display: block;
     text-decoration: none;
+
+    &:after {
+        height: 4px;
+        margin-top: 2px;
+        content: "";
+        display: block;
+        width: 0;
+    }
+
+    &:hover::after {
+        transition: width 0.3s;
+        width: 100%;
+    }
 }
 
 .footer {
@@ -404,6 +417,12 @@ p.main_description span sup {
 /*
     Media Query
 */
+@media (max-width: 959px) {
+.trigger a.page-link:after {
+    background-color: $text-color-primary;
+}
+}
+
 @media (min-width: 960px) {
 
 html, body {
@@ -444,5 +463,8 @@ html, body {
     background: none;
     color: $white;
     font-size: 18px;
+}
+.trigger a.page-link:after {
+  background-color: $white;
 }
 }


### PR DESCRIPTION
안녕하세요! 참고용으로 보내드립니다.

<blockquote class="twitter-tweet"><p lang="ko" dir="ltr">오프라인 행사 포스터 같아서 괜찮아 보이네요! 메뉴 아이템마다 바닥 보더에서 애니매이팅 효과하고 모바일에서 햄버거 바 펼쳐질 때 페이드 인 추가 애니매이션 추가하면 더 자연스러울 것 같아요 😎 <a href="https://t.co/ShVGpkCIoH">pic.twitter.com/ShVGpkCIoH</a></p>&mdash; 팔육칩 (@x86chi) <a href="https://twitter.com/x86chi/status/1252834290074701824?ref_src=twsrc%5Etfw">April 22, 2020</a></blockquote>

사전 작업으로써 공통된 색상 코드 두가지를 (주 텍스트 및 흰색 값 고정) 변수로 만들었습니다.

편의상 SASS 의 nested 문법으로 작성했습니다.

> https://github.com/x86chi/ucpc2020-site/blob/31c23057d44fa1b7bf04e264886cbef114e5bd43/_sass/commons.scss#L387-L398